### PR TITLE
Feature/update unity2022.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Platform](https://img.shields.io/badge/platform-iOS16.0%2B%20%7C%20iPadOS16.0%2B-9cf)<br>
 ![Xcode](https://img.shields.io/badge/Xcode-14.1-blue)
-![Unity](https://img.shields.io/badge/Unity-2021.3.13f1-lightgrey)
+![Unity](https://img.shields.io/badge/Unity-2022.2.0f1-lightgrey)
 
 # LowLevelNativePluginWithMetal-Samples
 

--- a/UnityProjects/BuiltInRP/Packages/manifest.json
+++ b/UnityProjects/BuiltInRP/Packages/manifest.json
@@ -1,12 +1,13 @@
 {
   "dependencies": {
+    "com.unity.ai.navigation": "1.1.1",
     "com.unity.feature.development": "1.0.1",
-    "com.unity.ide.rider": "3.0.16",
-    "com.unity.ide.visualstudio": "2.0.16",
+    "com.unity.ide.rider": "3.0.17",
+    "com.unity.ide.visualstudio": "2.0.17",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
-    "com.unity.timeline": "1.6.4",
+    "com.unity.timeline": "1.7.2",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.7.8",
     "com.unity.modules.ai": "1.0.0",

--- a/UnityProjects/BuiltInRP/Packages/packages-lock.json
+++ b/UnityProjects/BuiltInRP/Packages/packages-lock.json
@@ -1,5 +1,14 @@
 {
   "dependencies": {
+    "com.unity.ai.navigation": {
+      "version": "1.1.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.ai": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.editorcoroutines": {
       "version": "1.0.0",
       "depth": 1,
@@ -20,16 +29,16 @@
       "source": "builtin",
       "dependencies": {
         "com.unity.ide.visualstudio": "2.0.16",
-        "com.unity.ide.rider": "3.0.15",
+        "com.unity.ide.rider": "3.0.16",
         "com.unity.ide.vscode": "1.2.5",
         "com.unity.editorcoroutines": "1.0.0",
         "com.unity.performance.profile-analyzer": "1.1.1",
-        "com.unity.test-framework": "1.1.31",
-        "com.unity.testtools.codecoverage": "1.0.1"
+        "com.unity.test-framework": "1.1.33",
+        "com.unity.testtools.codecoverage": "1.2.1"
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.16",
+      "version": "3.0.17",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -38,7 +47,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.16",
+      "version": "2.0.17",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -61,7 +70,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.settings-manager": {
-      "version": "1.0.3",
+      "version": "2.0.1",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
@@ -79,7 +88,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.testtools.codecoverage": {
-      "version": "1.0.1",
+      "version": "1.2.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -98,7 +107,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.timeline": {
-      "version": "1.6.4",
+      "version": "1.7.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -259,17 +268,6 @@
     "com.unity.modules.uielements": {
       "version": "1.0.0",
       "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.ui": "1.0.0",
-        "com.unity.modules.imgui": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.uielementsnative": "1.0.0"
-      }
-    },
-    "com.unity.modules.uielementsnative": {
-      "version": "1.0.0",
-      "depth": 1,
       "source": "builtin",
       "dependencies": {
         "com.unity.modules.ui": "1.0.0",

--- a/UnityProjects/BuiltInRP/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/UnityProjects/BuiltInRP/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -1,6 +1,4 @@
 {
-    "m_Name": "Settings",
-    "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
     "m_Dictionary": {
         "m_DictionaryValues": []
     }

--- a/UnityProjects/BuiltInRP/ProjectSettings/ProjectVersion.txt
+++ b/UnityProjects/BuiltInRP/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.13f1
-m_EditorVersionWithRevision: 2021.3.13f1 (9e7d58001ecf)
+m_EditorVersion: 2022.2.0f1
+m_EditorVersionWithRevision: 2022.2.0f1 (35dcd44975df)


### PR DESCRIPTION
- Unityを2022.2に更新
    - パッケージも更新
- `UnityFramework.h` は元ソースが変わって無さそうなので大丈夫そう